### PR TITLE
Fix build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
         libelf1 \
         libiberty-dev \
         libboost-all-dev \
+        libdw-dev \
         libtbb2 \
         libtbb-dev \
     && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*

--- a/libAflDyninst.cpp
+++ b/libAflDyninst.cpp
@@ -1,4 +1,5 @@
 #include "config.h" // do symlink: ln -s ../AFLplusplus/include afl
+#include "types.h" // Also needed via symlink for newer AFL versions
 #include "dyninstversion.h" // if this include errors, compile and install https://github.com/dyninst/dyninst
 #include <algorithm>
 #include <cstdio>


### PR DESCRIPTION
Updated to fix a couple build issues. libdw-dev appears to be required for dyninst, and afl++ no longer includes "types.h" in "config.h".